### PR TITLE
`build.ccache.global_storage` policy 默认打开方便多目录复用 ccache

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+    "default": true,
+    "MD024": false,
+    "MD013": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,9 @@
     "editor.formatOnSave": false,
     "cSpell.words": [
         "buildir",
+        "ccache",
         "dlang",
+        "Emmylua",
         "Luajit",
         "luarocks",
         "tbox",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#15](https://github.com/TOMO-CAT/xmake/pull/15): 添加 `config.debugdir` 函数并将 build batchjobs 写入到 debugdir 便于排查
 * [#17](https://github.com/TOMO-CAT/xmake/pull/17): 设置 test target 的默认超时时间 `run_timeout` 为 60 秒
 * [#18](https://github.com/TOMO-CAT/xmake/pull/18): 默认展示 brief build cache stats
+* [#20](https://github.com/TOMO-CAT/xmake/pull/20): `build.ccache.global_storage` policy 默认打开方便多目录复用 ccache
 
 ### Bugs 修复
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,0 @@
-# Changelog

--- a/xmake/core/project/policy.lua
+++ b/xmake/core/project/policy.lua
@@ -53,7 +53,7 @@ function policy.policies()
             -- C/C++ build cache
             ["build.ccache"]                      = {description = "Enable C/C++ build cache.", type = "boolean"},
             -- Use global storage if build.ccache is enabled
-            ["build.ccache.global_storage"]       = {description = "Use global storge if build.ccache is enabled.", type = "boolean"},
+            ["build.ccache.global_storage"]       = {description = "Use global storge if build.ccache is enabled.", default = true, type = "boolean"},
             -- Always update configfiles when building
             ["build.always_update_configfiles"]   = {description = "Always update configfiles when building.", type = "boolean"},
             -- Enable build warning output, it's enabled by default.


### PR DESCRIPTION
* 配置 markdownlint 的忽略规则
* `build.ccache.global_storage` policy 默认打开方便多目录复用 ccache