### PR TITLE
[Feature]: improve co update envs performance

### DIFF
--- a/docs/development/todo.md
+++ b/docs/development/todo.md
@@ -100,3 +100,21 @@ end)
 ## build/.pkg 也能存储非直接依赖三方库的软链
 
 目前 `build/.pkg` 只有直接依赖三方库的软链，对于一些场景不好调试。
+
+## 性能与代码质量优化（按优先级排序）
+
+### `co_lock` 基于 500ms 轮询的锁机制
+
+`scheduler:co_lock` 的实现是每 500ms 轮询一次锁状态，锁释放后等待的协程最多要等 500ms 才能被唤醒。在包安装等高频加锁场景下延迟会累积。建议在 `co_unlock` 时主动唤醒等待队列中的协程（类似条件变量的 notify 机制），实现零延迟的锁传递。
+
+### `_traceback` 函数三处几乎完全重复
+
+`sandbox._traceback`、`interpreter._traceback`、`sandbox_try._traceback` 三个函数实现几乎一模一样（遍历调用栈、格式化 `src_file`、处理 `@` 前缀），只有极小差异（`xpcall` 终止条件和 `diagnosis` 判断）。建议抽取公共的 `traceback_utils` 模块，三处通过参数差异化调用。
+
+### `poller_waitproc` 和 `poller_waitfs` 代码高度重复
+
+`scheduler.lua` 中这两个函数除了 `OT_PROC` vs `OT_FWATCHER` 的类型检查不同，其余逻辑完全一致（分配 pollerdata、检查 pending、插入 poller、注册 timer、suspend）。建议合并为通用的 `_poller_wait_object(obj, timeout, expected_otype)` 内部方法，减少约 60 行重复代码。
+
+### `prune_redundant_edges` 被注释掉，构建图存在冗余边
+
+`build.lua` 中 `batchjobs:prune_redundant_edges()` 被注释掉了。当前构建图在大型项目中可能包含大量冗余依赖边，导致调度器做不必要的等待判断。`jobpool.lua` 中的实现用了 DFS + ancestors 追踪，但 `table.contains` 是线性扫描，对大图效率不高。建议用 hashset 替代 table 做 ancestors 查找，修复后重新启用。

--- a/xmake/core/base/scheduler.lua
+++ b/xmake/core/base/scheduler.lua
@@ -289,7 +289,12 @@ function scheduler:_co_curdir_update(curdir)
     co_curdirs[running] = {curdir_hash, curdir}
 end
 
--- update the current environments hash of current coroutine
+-- update the current environments version of current coroutine
+--
+-- we use a monotonically increasing version counter instead of hashing all
+-- environment variables. this avoids the O(n^2) string concatenation,
+-- key sorting, and uuid4 computation on every environment change.
+-- see tests/benchmark/bench_co_curenvs_update.lua for benchmark results.
 function scheduler:_co_curenvs_update(envs)
 
     -- get running coroutine
@@ -298,22 +303,18 @@ function scheduler:_co_curenvs_update(envs)
         return
     end
 
-    -- save the current directory hash
-    local envs_hash = ""
-    envs = envs or os.getenvs()
-    for _, key in ipairs(table.orderkeys(envs)) do
-        envs_hash = envs_hash .. key:upper() .. envs[key]
-    end
-    envs_hash = hash.uuid4(envs_hash):sub(1, 8)
-    self._CO_CURENVS_HASH = envs_hash
+    -- bump the global version counter
+    local envs_version = (self._CO_CURENVS_VERSION or 0) + 1
+    self._CO_CURENVS_VERSION = envs_version
 
-    -- save the current directory for each coroutine
+    -- save the current version and envs snapshot for each coroutine
+    envs = envs or os.getenvs()
     local co_curenvs = self._CO_CURENVS
     if not co_curenvs then
         co_curenvs = {}
         self._CO_CURENVS = co_curenvs
     end
-    co_curenvs[running] = {envs_hash, envs}
+    co_curenvs[running] = {envs_version, envs}
 end
 
 -- resume it's waiting coroutine if all coroutines are dead in group
@@ -453,9 +454,9 @@ function scheduler:co_resume(co, ...)
         end
 
         -- has the current environments been changed? restore it
-        local curenvs = self._CO_CURENVS_HASH
+        local curenvs = self._CO_CURENVS_VERSION
         local oldenvs = self._CO_CURENVS and self._CO_CURENVS[running] or nil
-        if oldenvs and curenvs ~= oldenvs[1] and running:is_isolated() then -- hash changed?
+        if oldenvs and curenvs ~= oldenvs[1] and running:is_isolated() then -- version changed?
             os.setenvs(oldenvs[2])
         end
     end
@@ -478,9 +479,9 @@ function scheduler:co_suspend(...)
     end
 
     -- has the current environments been changed? restore it
-    local curenvs = self._CO_CURENVS_HASH
+    local curenvs = self._CO_CURENVS_VERSION
     local oldenvs = self._CO_CURENVS and self._CO_CURENVS[running] or nil
-    if oldenvs and curenvs ~= oldenvs[1] and running:is_isolated() then -- hash changed?
+    if oldenvs and curenvs ~= oldenvs[1] and running:is_isolated() then -- version changed?
         os.setenvs(oldenvs[2])
     end
 


### PR DESCRIPTION
scheduler.lua 第 293-308 行，每次协程切换或环境变更时，都会遍历所有环境变量，拼接成一个巨大的字符串再做 hash.uuid4：

```lua
for _, key in ipairs(table.orderkeys(envs)) do
    envs_hash = envs_hash .. key:upper() .. envs[key]
end
envs_hash = hash.uuid4(envs_hash):sub(1, 8)
```
table.orderkeys 需要排序，字符串拼接是 O(n²)（Lua 字符串不可变），再加上 uuid4 哈希。在高并发构建场景下，协程频繁切换会反复触发这段逻辑。建议用 table.concat 替代逐步拼接，或者对 envs table 做引用比较（如果 table 引用没变就跳过计算），甚至用增量哈希。